### PR TITLE
Correct Qt5 support; remove Qt4.

### DIFF
--- a/Dockerfile.main.alpine
+++ b/Dockerfile.main.alpine
@@ -7,8 +7,6 @@ ARG VERSION='NOT SET FROM CLI INVOCATION'
 ARG RUBY_EXTRA=''
 FROM jdickey/ruby:${RUBY_VERSION}-alpine${RUBY_EXTRA}-no-qt
 
-# should be 'libqt4-webkit libqt4-dev' for Qt4; 'qt5-qtwebkit-dev' for Qt5 (both Alpine)
-ARG QTLIBS='shouldbe-qt5-qtwebkit-dev shouldbe-qt5-qmake'
 ARG RUBY_VERSION
 ARG RUBY_EXTRA
 ARG VERSION
@@ -20,6 +18,6 @@ LABEL description="Base image for ${RUBY_VERSION}alpine-${RUBY_EXTRA} with Qt an
 LABEL includesQt=true
 LABEL version="${VERSION}"
 
-RUN apk add --no-cache libxml2-dev libxslt-dev $QTLIBS xvfb
+RUN apk add --no-cache libxml2-dev libxslt-dev qt5-qtwebkit-dev xvfb
 RUN QMAKE=/usr/lib/qt5/bin/qmake gem install capybara-webkit && \
     gem update && gem update --system && gem cleanup

--- a/Dockerfile.main.debian
+++ b/Dockerfile.main.debian
@@ -7,10 +7,12 @@ ARG VERSION='NOT SET FROM CLI INVOCATION'
 ARG RUBY_EXTRA=''
 FROM jdickey/ruby:${RUBY_VERSION}${RUBY_EXTRA}-no-qt
 
+# should be '/usr/lib/x86_64-linux-gnu/qt5/bin/qmake' for Qt5; '/usr/local/lib/qt4/bin/qmake' for Qt4
+ARG QMAKE_PATH
 ARG RUBY_VERSION
 ARG RUBY_EXTRA
 ARG VERSION
-# should be 'libqt4-webkit libqt4-dev qt4-qmake' for Qt4; 'libqtwebkit-dev qt5-qmake' for Qt5 (both Debian)
+# should be 'libqt4-webkit libqt4-dev qt4-qmake' for Qt4; 'libqt5webkit5-dev qt5-qmake' for Qt5 (both Debian)
 ARG QTLIBS="shouldbe-libqt4-webkit shouldbe-libqt4-dev shouldbe-qt4-qmake"
 
 ENV LANG en_US.UTF-8
@@ -23,4 +25,4 @@ LABEL version="${VERSION}"
 RUN apt-get update -qq && apt-get dist-upgrade -y && \
     apt-get install -y $QTLIBS libxml2-dev libxslt1-dev xvfb && \
     apt-get clean && find /var/lib/apt/lists/* -delete
-RUN gem install capybara-webkit && gem update && gem update --system && gem cleanup
+RUN QMAKE=${QMAKE_PATH} gem install capybara-webkit && gem update && gem update --system && gem cleanup

--- a/Dockerfile.main.debian
+++ b/Dockerfile.main.debian
@@ -7,13 +7,9 @@ ARG VERSION='NOT SET FROM CLI INVOCATION'
 ARG RUBY_EXTRA=''
 FROM jdickey/ruby:${RUBY_VERSION}${RUBY_EXTRA}-no-qt
 
-# should be '/usr/lib/x86_64-linux-gnu/qt5/bin/qmake' for Qt5; '/usr/local/lib/qt4/bin/qmake' for Qt4
-ARG QMAKE_PATH
 ARG RUBY_VERSION
 ARG RUBY_EXTRA
 ARG VERSION
-# should be 'libqt4-webkit libqt4-dev qt4-qmake' for Qt4; 'libqt5webkit5-dev qt5-qmake' for Qt5 (both Debian)
-ARG QTLIBS="shouldbe-libqt4-webkit shouldbe-libqt4-dev shouldbe-qt4-qmake"
 
 ENV LANG en_US.UTF-8
 ENV LC_ALL C
@@ -23,6 +19,6 @@ LABEL includesQt=true
 LABEL version="${VERSION}"
 
 RUN apt-get update -qq && apt-get dist-upgrade -y && \
-    apt-get install -y $QTLIBS libxml2-dev libxslt1-dev xvfb && \
+    apt-get install -y libqt5webkit5-dev qt5-qmake libxml2-dev libxslt1-dev xvfb && \
     apt-get clean && find /var/lib/apt/lists/* -delete
-RUN QMAKE=${QMAKE_PATH} gem install capybara-webkit && gem update && gem update --system && gem cleanup
+RUN QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake gem install capybara-webkit && gem update && gem update --system && gem cleanup

--- a/README.md
+++ b/README.md
@@ -3,18 +3,21 @@
 # Contents
 
 - [Overview](#overview)
+  * [IMPORTANT NOTES for Image Prior To Version 0.13.0](#important-notes-for-image-prior-to-version-0130)
+  * [DEPRECATION NOTICE for Ruby Versions Prior to 2.4.4](#deprecation-notice-for-ruby-versions-prior-to-244)
   * [Supported Tags](#supported-tags)
     + [Logical but Nonexistent Tags](#logical-but-nonexistent-tags)
     + [What? No Dockerfiles?](#what-no-dockerfiles)
 - [Software](#software)
   * [Debian Stretch or Jessie](#debian-stretch-or-jessie)
     + [Base Software](#base-software)
-    + [Qt5 Software (for Stretch)](#qt5-software-for-stretch)
-    + [Qt4 Software (for Jessie)](#qt4-software-for-jessie)
+    + [Qt5 Software](#qt5-software)
   * [Alpine Linux](#alpine-linux)
     + [Base Software](#base-software-1)
-    + [Qt5 Software](#qt5-software)
+    + [Qt5 Software](#qt5-software-1)
 - [Changelog](#changelog)
+  * [0.13.0 (11 June 2018)](#0130-11-june-2018)
+  * [0.12.0 (11 April 2018) WITHDRAWN &mdash; DO NOT USE](#0120-11-april-2018-withdrawn-mdash-do-not-use)
   * [0.11.2 (15 March 2018)](#0112-15-march-2018)
   * [0.11.1 (7 March 2018)](#0111-7-march-2018)
   * [0.11.0 (4 March 2018)](#0110-4-march-2018)
@@ -29,11 +32,19 @@
 
 I *often* build from Ruby [official base images](https://hub.docker.com/_/ruby/), install additional software packages, and do some basic Ruby housekeeping (installing Bundler and making sure the system Gems are up-to-date). Building against [`2.4.2-jessie`](https://github.com/docker-library/ruby/blob/73d3ed6b06738a7457a24fba9024cad303829c0a/2.4/jessie/Dockerfile) on a 2011 iMac and a decent Net connection, this can take about *20 minutes.* Repeat this half-a-dozen times over the course of a day and you've lost two hours. As Orwell wrote, *doubleplus ungood.*
 
+## IMPORTANT NOTES for Image Prior To Version 0.13.0
+
+Basically, *please do not use them.* Rebuild any of your images using `jdickey/ruby` as a base using the current-at-the-time-of-writing Version 0.13.0 or later. The Alpine images are believed to be OK, but the Debian images, even those claiming to support Qt5, in fact have a mixture of Qt4 and Qt5 which causes several versions of `capybara-webkit` to have Issues, and which imminent future versions of `capybara-webkit` will not support, as they've officially deprecated Qt4. To find which version of the image you're working with, run the command line `docker inspect jdickey/ruby:2.5.1 | grep '"version"'`, substituting the tag of the image you are actually using if not `2.5.1`.
+
+## DEPRECATION NOTICE for Ruby Versions Prior to 2.4.4
+
+Notice is hereby served that the first version of these images released after 11 September 2018, 3 months from the release of Version 0.13.0, will contain **no** images for Ruby versions `2.4.2` or `2.4.3`. Please upgrade your Ruby version using appropriate images, as the affected Ruby versions presently supported by these images are no longer receiving official support from ruby-lang.org.
+
 ## Supported Tags
 
 Each image has one tag that follows the format `2.x.y-os_build[-no-qt]`, where
 
-1. `2.x.y` is the full version number of the Ruby version hosted by the image, which will be one of `2.5.0` (the current version), `2.4.3`, or `2.4.2`;
+1. `2.x.y` is the full version number of the Ruby version hosted by the image, which will be one of `2.5.1` (the current version), `2.5.0`, `2.4.4`, `2.4.3`, or `2.4.2`;
 2. `os_build` identifies which OS and variant the image was based on. These can be any one of
 	1. `jessie`: Debian [Jessie](https://en.wikipedia.org/wiki/Debian#Code_names) (8.0);
 	2. `slim-jessie`: A "slim" version of Jessie, containing fewer packages by default (and thus with a considerably smaller image size);
@@ -42,19 +53,19 @@ Each image has one tag that follows the format `2.x.y-os_build[-no-qt]`, where
 	5. `alpine3.7` (synonyms: `alpine37` and `alpine`): Alpine Linux 3.7, a minimalist Linux distribution. (There is no 'slim' version of `alpine`; it's already the smallest of the listed images);
 3. The suffix `-no-qt` indicates that the image has been built *without* the Qt OS-level libraries and tools needed to run the [Capybara](https://teamcapybara.github.io/capybara/) test framework (and thus does not include Capybara itself or the `capybara-webkit` headless browser).
 
-The `latest` tag identifies the latest version of Ruby (as of December 2017, version 2.5.0) on the latest, non-`slim` version of Debian (currently `stretch`), built *with* the Qt and Capybara tools. It should be the default choice when you simply want the most recent supported Ruby version, but is not recommended for production use in most cases. (We recommend exploring basing your image on an `alpine` and `-no-qt` build for production.)
+The `latest` tag identifies the latest version of Ruby (as of June 2018, version 2.5.1) on the latest, non-`slim` version of Debian (currently `stretch`), built *with* the Qt and Capybara tools. It should be the default choice when you simply want the most recent supported Ruby version, but is not recommended for production use in most cases. (We recommend exploring basing your image on an `alpine` and `-no-qt` build for production.)
 
-Minor-version tags such as `2.4-jessie` or `2.5-alpine-no-qt` identify the latest supported release of that minor version of Ruby on the specified OS build. As later versions of Ruby are released and supported (e.g., a hypothetical 2.4.4 or 2.5.1), the corresponding minor-version tag will be redefined to match the new full-version-number tag.
+Minor-version tags such as `2.4-jessie` or `2.5-alpine-no-qt` identify the latest supported release of that minor version of Ruby on the specified OS build. As later versions of Ruby are released and supported (e.g., a hypothetical 2.4.5 or 2.5.2), the corresponding minor-version tag will be redefined to match the new full-version-number tag.
 
-Major-version tags (e.g., `2-stretch` or `2-alpine3.7`) identify the latest supported minor release of the latest supported major release of Ruby (currently `2.5.0`), and are updated in a manner analogous to minor-version tags; i.e., when Ruby 2.6 is released (expected to be in December, 2018), each major-version tag will be updated to match `2.6.0` on each respective operating system (e.g., `2.6.0-stretch`).
+Major-version tags (e.g., `2-stretch` or `2-alpine3.7`) identify the latest supported minor release of the latest supported major release of Ruby (currently `2.5.1`), and are updated in a manner analogous to minor-version tags; i.e., when Ruby 2.6 is released (expected to be in December, 2018), each major-version tag will be updated to match `2.6.0` on each respective operating system (e.g., `2.6.0-stretch`).
 
 Tags which *do not* include a Ruby version number are built using the latest supported version of Ruby on the OS build identified by their name, e.g., `stretch-no-qt` or `alpine`, built with Qt and Capybara. This differs from `latest` in that `latest` is presently defined as always being on the latest non-`slim` Debian build (currently `stretch`).
 
-Finally, the Alpine Linux OS build names differ from the Debian conventions in that Alpine is the only OS build that encodes (major and minor) version numbers. Hence, `alpine3.7` is synonymous with `alpine37` and, until a newer version of Alpine is supported by the [official Ruby base images](https://hub.docker.com/_/ruby/), `alpine` is as well. That is to say that `2.5.0-alpine3.7` and `alpine` (presently) reference the same image.
+Finally, the Alpine Linux OS build names differ from the Debian conventions in that Alpine is the only OS build that encodes (major and minor) version numbers. Hence, `alpine3.7` is synonymous with `alpine37` and, until a newer version of Alpine is supported by the [official Ruby base images](https://hub.docker.com/_/ruby/), `alpine` is as well. That is to say that `2.5.1-alpine3.7` and `alpine` (presently) reference the same image.
 
 ### Logical but Nonexistent Tags
 
-Why no tags for, e.g., `2-slim-jessie`? We use tag names intended to be consistent with those of the [official Ruby Docker images](https://hub.docker.com/_/ruby/); the unadorned `2` states that the tag is for the latest 2.*x* Ruby version. No Debian Jessie-based images exist for Ruby versions later than the outdated 2.4.*x* (as of early March 2018, 2.4.3) release. It is possible that some such tags were created in error and not caught prior to release on Docker Hub; if you find one, please [open an issue](https://github.com/jdickey/docker-ruby/issues). *Thanks!*
+Why no tags for, e.g., `2-slim-jessie`? We use tag names intended to be consistent with those of the [official Ruby Docker images](https://hub.docker.com/_/ruby/); the unadorned `2` states that the tag is for the latest 2.*x* Ruby version. No Debian Jessie-based images exist for Ruby versions later than the outdated 2.4.*x* (as of June 2018, 2.4.4) release. It is possible that some such tags were created in error and not caught prior to release on Docker Hub; if you find one, please [open an issue](https://github.com/jdickey/docker-ruby/issues). *Thanks!*
 
 ### What? No Dockerfiles?
 
@@ -69,6 +80,8 @@ Versions of these images prior to [Release 0.11.0](#changelog) published `Docker
 
 ## Debian Stretch or Jessie
 
+Note that we *recommend* use of Stretch over Jessie where practical. Support for Jessie is likely to be discontinued at a future date when Stretch will still be supported.
+
 ### Base Software
 
 The following Debian packages are installed in Debian-based images of this repo:
@@ -80,21 +93,13 @@ The following Debian packages are installed in Debian-based images of this repo:
 * `wget`
 * `zsh`
 
-### Qt5 Software (for Stretch)
+### Qt5 Software
 
-The following Debian packages are installed in Stretch images not tagged `no-qt` of this repo. This is useful for test-mode builds that include tools such as [Capybara](https://github.com/teamcapybara/capybara):
+The following Debian packages are installed in all Debian images not tagged `no-qt` of this repo. This is useful for test-mode builds that include tools such as [Capybara](https://github.com/teamcapybara/capybara):
 
+* `libqt5webkit5-dev`
+* `qt5-qmake`
 * `libqtwebkit-dev`
-* `libxml2-dev`
-* `libxslt1-dev`
-* `xvfb`
-
-### Qt4 Software (for Jessie)
-
-The following Debian packages are installed in Jessie images not tagged `no-qt` of this repo. This is useful for test-mode builds that include tools such as [Capybara](https://github.com/teamcapybara/capybara):
-
-* `libqt4-dev`
-* `libqt4-webkit`
 * `libxml2-dev`
 * `libxslt1-dev`
 * `xvfb`
@@ -122,6 +127,14 @@ The following Alpine packages are installed in Alpine images not tagged `no-qt` 
 * `xvfb`
 
 # Changelog
+
+## 0.13.0 (11 June 2018)
+
+* Corrected Qt5 library specification, eliminating Qt4.
+* Simplified image-build process.
+* Added deprecation notice for Ruby < 2.4.4 to this README.
+
+## 0.12.0 (11 April 2018) WITHDRAWN &mdash; DO NOT USE
 
 ## 0.11.2 (15 March 2018)
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -52,7 +52,8 @@ docker build --build-arg RUBY_VERSION=2.5.1 \
 
 docker build --build-arg RUBY_VERSION=2.5.1 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.1-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -65,7 +66,8 @@ docker build --build-arg RUBY_VERSION=2.5.1 \
 
 docker build --build-arg RUBY_VERSION=2.5.1 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.1-slim-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -82,7 +84,8 @@ docker build --build-arg RUBY_VERSION=2.5.0 \
 
 docker build --build-arg RUBY_VERSION=2.5.0 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.0-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -95,7 +98,8 @@ docker build --build-arg RUBY_VERSION=2.5.0 \
 
 docker build --build-arg RUBY_VERSION=2.5.0 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.0-slim-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -146,7 +150,8 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -159,7 +164,8 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqtwebkit-dev qt5-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-slim-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -176,7 +182,8 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -189,7 +196,8 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-slim-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -224,7 +232,8 @@ docker build --build-arg RUBY_VERSION=2.4.3 \
 
 docker build --build-arg RUBY_VERSION=2.4.3 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.3-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -237,7 +246,8 @@ docker build --build-arg RUBY_VERSION=2.4.3 \
 
 docker build --build-arg RUBY_VERSION=2.4.3 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.3-slim-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -271,7 +281,8 @@ docker build --build-arg RUBY_VERSION=2.4.2 \
 
 docker build --build-arg RUBY_VERSION=2.4.2 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.2-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -284,7 +295,8 @@ docker build --build-arg RUBY_VERSION=2.4.2 \
 
 docker build --build-arg RUBY_VERSION=2.4.2 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt4-webkit libqt4-dev qt4-qmake" \
+             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
+             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.2-slim-jessie' \
              --squash --file Dockerfile.main.debian .

--- a/build-all.sh
+++ b/build-all.sh
@@ -37,6 +37,7 @@ if [[ -z "${DOCKER_RUBY_VERSION}" ]]; then
   echo You MUST define the DOCKER_RUBY_VERSION environment variable when using this script.
   echo It will be encoded into the built images as a version ID.
   echo Example usage: DOCKER_RUBY_VERSION=0.27.0 bash ./build_all.sh
+  sleep 3
   return 1
 fi
 
@@ -52,8 +53,6 @@ docker build --build-arg RUBY_VERSION=2.5.1 \
 
 docker build --build-arg RUBY_VERSION=2.5.1 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.1-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -66,11 +65,10 @@ docker build --build-arg RUBY_VERSION=2.5.1 \
 
 docker build --build-arg RUBY_VERSION=2.5.1 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.1-slim-stretch' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.5.0 on Debian Stretch
@@ -84,8 +82,6 @@ docker build --build-arg RUBY_VERSION=2.5.0 \
 
 docker build --build-arg RUBY_VERSION=2.5.0 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.0-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -98,11 +94,10 @@ docker build --build-arg RUBY_VERSION=2.5.0 \
 
 docker build --build-arg RUBY_VERSION=2.5.0 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.5.0-slim-stretch' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.5.1 on Alpine 3.7
@@ -117,9 +112,9 @@ docker build --build-arg RUBY_VERSION=2.5.1 \
 docker build --build-arg RUBY_VERSION=2.5.1 \
              --build-arg RUBY_EXTRA='3.7' \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
-             --build-arg QTLIBS=qt5-qtwebkit-dev \
              --tag 'jdickey/ruby:2.5.1-alpine3.7' \
              --squash --file Dockerfile.main.alpine .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.5.0 on Alpine 3.7
@@ -134,9 +129,9 @@ docker build --build-arg RUBY_VERSION=2.5.0 \
 docker build --build-arg RUBY_VERSION=2.5.0 \
              --build-arg RUBY_EXTRA='3.7' \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
-             --build-arg QTLIBS=qt5-qtwebkit-dev \
              --tag 'jdickey/ruby:2.5.0-alpine3.7' \
              --squash --file Dockerfile.main.alpine .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.4 on Debian Stretch
@@ -150,8 +145,6 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-stretch' \
              --squash --file Dockerfile.main.debian .
@@ -164,11 +157,10 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-slim-stretch' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-slim-stretch' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.4 on Debian Jessie
@@ -182,8 +174,6 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -196,11 +186,10 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.4-slim-jessie' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 
 ###
@@ -216,9 +205,9 @@ docker build --build-arg RUBY_VERSION=2.4.4 \
 docker build --build-arg RUBY_VERSION=2.4.4 \
              --build-arg RUBY_EXTRA='3.7' \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
-             --build-arg QTLIBS=qt5-qtwebkit-dev \
              --tag 'jdickey/ruby:2.4.4-alpine3.7' \
              --squash --file Dockerfile.main.alpine .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.3 on Debian Jessie
@@ -232,8 +221,6 @@ docker build --build-arg RUBY_VERSION=2.4.3 \
 
 docker build --build-arg RUBY_VERSION=2.4.3 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.3-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -246,11 +233,10 @@ docker build --build-arg RUBY_VERSION=2.4.3 \
 
 docker build --build-arg RUBY_VERSION=2.4.3 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.3-slim-jessie' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.3 on Alpine 3.7
@@ -265,9 +251,9 @@ docker build --build-arg RUBY_VERSION=2.4.3 \
 docker build --build-arg RUBY_VERSION=2.4.3 \
              --build-arg RUBY_EXTRA='3.7' \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
-             --build-arg QTLIBS=qt5-qtwebkit-dev \
              --tag 'jdickey/ruby:2.4.3-alpine3.7' \
              --squash --file Dockerfile.main.alpine .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.2 on Debian Jessie
@@ -281,8 +267,6 @@ docker build --build-arg RUBY_VERSION=2.4.2 \
 
 docker build --build-arg RUBY_VERSION=2.4.2 \
              --build-arg RUBY_EXTRA='-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.2-jessie' \
              --squash --file Dockerfile.main.debian .
@@ -295,11 +279,10 @@ docker build --build-arg RUBY_VERSION=2.4.2 \
 
 docker build --build-arg RUBY_VERSION=2.4.2 \
              --build-arg RUBY_EXTRA='-slim-jessie' \
-             --build-arg QTLIBS="libqt5webkit5-dev qt5-qmake" \
-             --build-arg QMAKE_PATH="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake" \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
              --tag 'jdickey/ruby:2.4.2-slim-jessie' \
              --squash --file Dockerfile.main.debian .
+docker container prune -f && docker image prune -f
 
 ###
 ### 2.4.2 on Alpine 3.7
@@ -314,9 +297,9 @@ docker build --build-arg RUBY_VERSION=2.4.2 \
 docker build --build-arg RUBY_VERSION=2.4.2 \
              --build-arg RUBY_EXTRA='3.7' \
              --build-arg VERSION=$DOCKER_RUBY_VERSION \
-             --build-arg QTLIBS=qt5-qtwebkit-dev \
              --tag 'jdickey/ruby:2.4.2-alpine3.7' \
              --squash --file Dockerfile.main.alpine .
+docker container prune -f && docker image prune -f
 
 ###
 ### Version tags
@@ -329,12 +312,6 @@ echo "Done!"
 ###
 ### Fin
 ###
-
-
-echo -n 'Failed containers deleted: '
-docker container prune -f | grep 'deleted:' | wc -l
-echo -n "Temporary images deleted: "
-docker image prune -f | grep 'deleted:' | wc -l
 
 echo 'All images created and tagged.'
 echo "Use 'docker image ls jdickey/ruby' to see a complete list."


### PR DESCRIPTION
We'd thought we had Qt5 fixed with the previous commits and the 0.12.0 volumes.

We were wrong.

Please, if you're using any Qt-based variant of these images, pull 0.13.0 from hub.docker.com *now*.